### PR TITLE
argocd: add RBAC, main config, local accounts, SSH known-hosts, network policy and pod security hardening

### DIFF
--- a/ansible/inventory/group_vars/k3s_servers/argocd.yml
+++ b/ansible/inventory/group_vars/k3s_servers/argocd.yml
@@ -8,7 +8,63 @@ argocd_tls_secret: "argocd-tls"
 
 argocd_enable_http_redirect: true
 
-argocd_enable_basic_auth: true
+argocd_enable_rbac_config: true
+argocd_rbac_policy_default: "role:readonly"
+argocd_rbac_scopes: "[groups]"
+argocd_rbac_policy_csv_lines:
+  - "g, team-admins, role:admin"
+  - "g, team-developers, role:edit"
+  - "p, role:edit, applications, *, argocd/*, allow"
+argocd_rbac_extra_data: {}
+
+argocd_enable_main_config: true
+argocd_cm_data:
+  url: "https://argocd.wlodzimierrr.co.uk"
+  "server.insecure": "false"
+  "admin.enabled": "false"
+
+argocd_enable_local_accounts: true
+argocd_local_accounts_password_mtime: "2026-01-01T00:00:00Z"
+argocd_local_accounts:
+  - username: "wlodzimierrr"
+    capabilities: ["login", "apiKey"]
+    password_hash: "$2y$05$voQCOpNZ61BGPd/3Re1MjuMNR56DUISXkWEPJM1iAOiF8ZPGreKJG"
+    password_mtime: "2026-01-01T00:00:00Z"
+
+argocd_enable_ssh_known_hosts_config: false
+argocd_ssh_known_hosts_entries: []
+
+argocd_enable_server_security_patch: true
+argocd_server_deployment_patch:
+  spec:
+    template:
+      spec:
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 999
+          runAsGroup: 999
+          fsGroup: 999
+        containers:
+          - name: argocd-server
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop: ["ALL"]
+
+argocd_enable_network_policy: true
+argocd_network_policy_allow_same_namespace: true
+argocd_networkpolicy_ingress_from:
+  - namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: kube-system
+    podSelector:
+      matchLabels:
+        app.kubernetes.io/name: traefik
+
+argocd_show_initial_admin_password: false
+
+argocd_enable_basic_auth: false
 argocd_basic_auth_secret_name: "argocd-basic-auth"
 argocd_basic_auth_users:
   - "wlodzimierrr:$2y$05$voQCOpNZ61BGPd/3Re1MjuMNR56DUISXkWEPJM1iAOiF8ZPGreKJG"

--- a/ansible/roles/argocd/tasks/main.yml
+++ b/ansible/roles/argocd/tasks/main.yml
@@ -24,6 +24,175 @@
   args:
     executable: /bin/bash
 
+- name: Assert RBAC policy lines when custom RBAC is enabled
+  assert:
+    that:
+      - argocd_rbac_policy_csv_lines is defined
+      - (argocd_rbac_policy_csv_lines | length) > 0
+    fail_msg: "Custom RBAC enabled but argocd_rbac_policy_csv_lines is missing/empty."
+  when: argocd_enable_rbac_config | default(false)
+
+- name: Render Argo CD RBAC ConfigMap
+  template:
+    src: argocd_rbac_cm.yml.j2
+    dest: /tmp/argocd-rbac-cm.yml
+    mode: "0644"
+  when: argocd_enable_rbac_config | default(false)
+
+- name: Validate Argo CD RBAC ConfigMap YAML (kubectl client dry-run)
+  shell: |
+    set -euo pipefail
+    kubectl apply --dry-run=client -f /tmp/argocd-rbac-cm.yml >/dev/null
+  args:
+    executable: /bin/bash
+  when: argocd_enable_rbac_config | default(false)
+
+- name: Apply Argo CD RBAC ConfigMap
+  shell: |
+    set -euo pipefail
+    kubectl apply -f /tmp/argocd-rbac-cm.yml
+  args:
+    executable: /bin/bash
+  when: argocd_enable_rbac_config | default(false)
+
+- name: Render Argo CD main ConfigMap
+  template:
+    src: argocd_cm.yml.j2
+    dest: /tmp/argocd-cm.yml
+    mode: "0644"
+  when: argocd_enable_main_config | default(false)
+
+- name: Validate Argo CD main ConfigMap YAML (kubectl client dry-run)
+  shell: |
+    set -euo pipefail
+    kubectl apply --dry-run=client -f /tmp/argocd-cm.yml >/dev/null
+  args:
+    executable: /bin/bash
+  when: argocd_enable_main_config | default(false)
+
+- name: Apply Argo CD main ConfigMap
+  shell: |
+    set -euo pipefail
+    kubectl apply -f /tmp/argocd-cm.yml
+  args:
+    executable: /bin/bash
+  when: argocd_enable_main_config | default(false)
+
+- name: Assert local account vars when local Argo CD accounts are enabled
+  assert:
+    that:
+      - argocd_local_accounts is defined
+      - (argocd_local_accounts | length) > 0
+      - (argocd_local_accounts | map(attribute='username') | list | length) == (argocd_local_accounts | map(attribute='username') | unique | list | length)
+      - argocd_local_accounts | selectattr('username', 'defined') | list | length == (argocd_local_accounts | length)
+      - argocd_local_accounts | selectattr('capabilities', 'defined') | list | length == (argocd_local_accounts | length)
+      - argocd_local_accounts | selectattr('password_hash', 'defined') | list | length == (argocd_local_accounts | length)
+    fail_msg: "Local accounts enabled but argocd_local_accounts is missing required username/capabilities/password_hash fields."
+  when: argocd_enable_local_accounts | default(false)
+
+- name: Build argocd-cm patch data for local accounts
+  set_fact:
+    argocd_local_accounts_cm_patch_data: "{{ argocd_local_accounts_cm_patch_data | default({}) | combine({ ('accounts.' ~ item.username): (item.capabilities | join(',')) }) }}"
+  loop: "{{ argocd_local_accounts | default([]) }}"
+  when: argocd_enable_local_accounts | default(false)
+
+- name: Patch argocd-cm with local accounts capabilities
+  shell: |
+    set -euo pipefail
+    ns="{{ argocd_namespace }}"
+    kubectl -n "$ns" patch configmap argocd-cm --type='merge' -p='{{ {"data": (argocd_local_accounts_cm_patch_data | default({}))} | to_json }}'
+  args:
+    executable: /bin/bash
+  when: argocd_enable_local_accounts | default(false)
+
+- name: Build argocd-secret patch data for local account password hashes
+  set_fact:
+    argocd_local_accounts_secret_patch_data: "{{ argocd_local_accounts_secret_patch_data | default({}) | combine({ ('accounts.' ~ item.username ~ '.password'): item.password_hash, ('accounts.' ~ item.username ~ '.passwordMtime'): (item.password_mtime | default(argocd_local_accounts_password_mtime)) }) }}"
+  loop: "{{ argocd_local_accounts | default([]) }}"
+  when: argocd_enable_local_accounts | default(false)
+
+- name: Patch argocd-secret with local account password hashes
+  shell: |
+    set -euo pipefail
+    ns="{{ argocd_namespace }}"
+    kubectl -n "$ns" patch secret argocd-secret --type='merge' -p='{{ {"stringData": (argocd_local_accounts_secret_patch_data | default({}))} | to_json }}'
+  args:
+    executable: /bin/bash
+  when: argocd_enable_local_accounts | default(false)
+
+- name: Restart argocd-server to reload account config
+  shell: |
+    set -euo pipefail
+    ns="{{ argocd_namespace }}"
+    kubectl -n "$ns" rollout restart deploy/argocd-server
+    kubectl -n "$ns" rollout status deploy/argocd-server --timeout=180s
+  args:
+    executable: /bin/bash
+  when: argocd_enable_local_accounts | default(false)
+
+- name: Assert SSH known hosts lines when known hosts ConfigMap is enabled
+  assert:
+    that:
+      - argocd_ssh_known_hosts_entries is defined
+      - (argocd_ssh_known_hosts_entries | length) > 0
+    fail_msg: "SSH known-hosts enabled but argocd_ssh_known_hosts_entries is missing/empty."
+  when: argocd_enable_ssh_known_hosts_config | default(false)
+
+- name: Render Argo CD SSH known hosts ConfigMap
+  template:
+    src: argocd_ssh_known_hosts_cm.yml.j2
+    dest: /tmp/argocd-ssh-known-hosts-cm.yml
+    mode: "0644"
+  when: argocd_enable_ssh_known_hosts_config | default(false)
+
+- name: Validate Argo CD SSH known hosts ConfigMap YAML (kubectl client dry-run)
+  shell: |
+    set -euo pipefail
+    kubectl apply --dry-run=client -f /tmp/argocd-ssh-known-hosts-cm.yml >/dev/null
+  args:
+    executable: /bin/bash
+  when: argocd_enable_ssh_known_hosts_config | default(false)
+
+- name: Apply Argo CD SSH known hosts ConfigMap
+  shell: |
+    set -euo pipefail
+    kubectl apply -f /tmp/argocd-ssh-known-hosts-cm.yml
+  args:
+    executable: /bin/bash
+  when: argocd_enable_ssh_known_hosts_config | default(false)
+
+- name: Patch argocd-server pod security context
+  shell: |
+    set -euo pipefail
+    ns="{{ argocd_namespace }}"
+    kubectl -n "$ns" patch deploy argocd-server --type='merge' -p='{{ argocd_server_deployment_patch | to_json }}'
+  args:
+    executable: /bin/bash
+  when: argocd_enable_server_security_patch | default(false)
+
+- name: Render Argo CD server network policy
+  template:
+    src: argocd_networkpolicy.yml.j2
+    dest: /tmp/argocd-server-networkpolicy.yml
+    mode: "0644"
+  when: argocd_enable_network_policy | default(false)
+
+- name: Validate Argo CD server network policy YAML (kubectl client dry-run)
+  shell: |
+    set -euo pipefail
+    kubectl apply --dry-run=client -f /tmp/argocd-server-networkpolicy.yml >/dev/null
+  args:
+    executable: /bin/bash
+  when: argocd_enable_network_policy | default(false)
+
+- name: Apply Argo CD server network policy
+  shell: |
+    set -euo pipefail
+    kubectl apply -f /tmp/argocd-server-networkpolicy.yml
+  args:
+    executable: /bin/bash
+  when: argocd_enable_network_policy | default(false)
+
 - name: Wait for Argo CD workloads (deployments + statefulsets)
   shell: |
     set -euo pipefail
@@ -162,6 +331,7 @@
     echo
   args:
     executable: /bin/bash
+  when: argocd_show_initial_admin_password | default(true)
 
 - name: Show Argo CD ingress + cert status
   shell: |

--- a/ansible/roles/argocd/templates/argocd_cm.yml.j2
+++ b/ansible/roles/argocd/templates/argocd_cm.yml.j2
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-cm
+  namespace: {{ argocd_namespace }}
+data:
+{% for key, value in (argocd_cm_data | default({}) | dictsort) %}
+{% if '\n' in (value | string) %}
+  {{ key }}: |
+{{ value | string | indent(4, true) }}
+{% else %}
+  {{ key }}: {{ value | string | quote }}
+{% endif %}
+{% endfor %}

--- a/ansible/roles/argocd/templates/argocd_networkpolicy.yml.j2
+++ b/ansible/roles/argocd/templates/argocd_networkpolicy.yml.j2
@@ -1,0 +1,36 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: argocd-server-ingress
+  namespace: {{ argocd_namespace }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: argocd-server
+  policyTypes:
+    - Ingress
+  ingress:
+    - from:
+{% if argocd_network_policy_allow_same_namespace | default(true) %}
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: {{ argocd_namespace }}
+{% endif %}
+{% for peer in (argocd_networkpolicy_ingress_from | default([])) %}
+        -
+{% if peer.namespaceSelector is defined %}
+          namespaceSelector:
+{{ peer.namespaceSelector | to_nice_yaml(indent=2) | indent(12, true) }}
+{% endif %}
+{% if peer.podSelector is defined %}
+          podSelector:
+{{ peer.podSelector | to_nice_yaml(indent=2) | indent(12, true) }}
+{% endif %}
+{% if peer.ipBlock is defined %}
+          ipBlock:
+{{ peer.ipBlock | to_nice_yaml(indent=2) | indent(12, true) }}
+{% endif %}
+{% endfor %}
+      ports:
+        - protocol: TCP
+          port: 8080

--- a/ansible/roles/argocd/templates/argocd_rbac_cm.yml.j2
+++ b/ansible/roles/argocd/templates/argocd_rbac_cm.yml.j2
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-rbac-cm
+  namespace: {{ argocd_namespace }}
+data:
+{% if argocd_rbac_policy_default is defined and argocd_rbac_policy_default %}
+  policy.default: {{ argocd_rbac_policy_default | quote }}
+{% endif %}
+  policy.csv: |
+{% for line in (argocd_rbac_policy_csv_lines | default([])) %}
+    {{ line }}
+{% endfor %}
+{% if argocd_rbac_scopes is defined and argocd_rbac_scopes %}
+  scopes: {{ argocd_rbac_scopes | quote }}
+{% endif %}
+{% for key, value in (argocd_rbac_extra_data | default({}) | dictsort) %}
+{% if '\n' in (value | string) %}
+  {{ key }}: |
+{{ value | string | indent(4, true) }}
+{% else %}
+  {{ key }}: {{ value | string | quote }}
+{% endif %}
+{% endfor %}

--- a/ansible/roles/argocd/templates/argocd_ssh_known_hosts_cm.yml.j2
+++ b/ansible/roles/argocd/templates/argocd_ssh_known_hosts_cm.yml.j2
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-ssh-known-hosts-cm
+  namespace: {{ argocd_namespace }}
+data:
+  ssh_known_hosts: |
+{% for line in (argocd_ssh_known_hosts_entries | default([])) %}
+    {{ line }}
+{% endfor %}


### PR DESCRIPTION
### Motivation
- Provide configurable Argo CD RBAC and main `argocd-cm` settings so the installation can enforce desired access policies.
- Manage local Argo CD accounts and SSH known-hosts from inventory to avoid manual secrets/configmap edits.
- Improve security posture by enforcing a non-root `argocd-server` pod security context and restricting network access with a NetworkPolicy.

### Description
- Added new inventory variables to `group_vars/k3s_servers/argocd.yml` to support RBAC (`argocd_enable_rbac_config`, `argocd_rbac_policy_csv_lines`, etc.), main config (`argocd_enable_main_config`, `argocd_cm_data`), local accounts (`argocd_enable_local_accounts`, `argocd_local_accounts`), SSH known-hosts, server security patch and network policy, and disabled basic auth by default.
- Introduced templates `argocd_rbac_cm.yml.j2`, `argocd_cm.yml.j2`, `argocd_ssh_known_hosts_cm.yml.j2`, and `argocd_networkpolicy.yml.j2` to render the respective Kubernetes resources.
- Extended `ansible/roles/argocd/tasks/main.yml` with assertions, rendering, `kubectl` client-side YAML validation, and apply/patch steps for RBAC configmap, main configmap, local account password/metadata patching, SSH known-hosts configmap, `argocd-server` deployment securityContext patch, and NetworkPolicy creation, plus conditional control of printing the initial admin password.
- Kept existing installation and rollout checks and added a restart/rollout of `argocd-server` when local accounts are patched.

### Testing
- No separate automated test suite was run as part of this change.
- The role now includes runtime YAML validation using `kubectl apply --dry-run=client` for ConfigMaps and NetworkPolicy which will execute during playbook runs when the respective features are enabled and should catch template/YAML issues.
- Existing rollout/wait checks using `kubectl rollout status` remain in place and will verify component readiness during runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a17f8162a88327a6934c51dc959f32)